### PR TITLE
feat(form-builder): host-driven supportedFieldTypes with per-type limits, DATE_TIME field, async lookup search

### DIFF
--- a/packages/crayons-extended/custom-objects/src/components.d.ts
+++ b/packages/crayons-extended/custom-objects/src/components.d.ts
@@ -578,10 +578,6 @@ export namespace Components {
          */
         "role": 'trial' | 'admin';
         /**
-          * flag to show date time field type or not
-         */
-        "showDateTimeField": boolean;
-        /**
           * flag to show dependentField for CONVERSATION_PROPERTIES or not
          */
         "showDependentField": boolean;
@@ -594,10 +590,6 @@ export namespace Components {
          */
         "showLookupField": boolean;
         /**
-          * flag to show multi select field type or not
-         */
-        "showMultiSelectField": boolean;
-        /**
           * flag to show relationshipTypeSelect dropdown or not
          */
         "showRelationshipTypeSelect": boolean;
@@ -605,6 +597,13 @@ export namespace Components {
           * flag to support dependentFields & Multi select dropdown within sections
          */
         "supportDependentAndMSDDInSections": boolean;
+        /**
+          * Host-driven list of supported field types and optional per-type limits
+         */
+        "supportedFieldTypes": Array<{
+    type: string;
+    limit?: number;
+  }>;
         /**
           * Theme configuration for the form builder UI
          */
@@ -1655,10 +1654,6 @@ declare namespace LocalJSX {
          */
         "role"?: 'trial' | 'admin';
         /**
-          * flag to show date time field type or not
-         */
-        "showDateTimeField"?: boolean;
-        /**
           * flag to show dependentField for CONVERSATION_PROPERTIES or not
          */
         "showDependentField"?: boolean;
@@ -1671,10 +1666,6 @@ declare namespace LocalJSX {
          */
         "showLookupField"?: boolean;
         /**
-          * flag to show multi select field type or not
-         */
-        "showMultiSelectField"?: boolean;
-        /**
           * flag to show relationshipTypeSelect dropdown or not
          */
         "showRelationshipTypeSelect"?: boolean;
@@ -1682,6 +1673,13 @@ declare namespace LocalJSX {
           * flag to support dependentFields & Multi select dropdown within sections
          */
         "supportDependentAndMSDDInSections"?: boolean;
+        /**
+          * Host-driven list of supported field types and optional per-type limits
+         */
+        "supportedFieldTypes"?: Array<{
+    type: string;
+    limit?: number;
+  }>;
         /**
           * Theme configuration for the form builder UI
          */

--- a/packages/crayons-extended/custom-objects/src/components.d.ts
+++ b/packages/crayons-extended/custom-objects/src/components.d.ts
@@ -590,6 +590,10 @@ export namespace Components {
          */
         "showLookupField": boolean;
         /**
+          * flag to show multi select field type or not
+         */
+        "showMultiSelectField": boolean;
+        /**
           * flag to show relationshipTypeSelect dropdown or not
          */
         "showRelationshipTypeSelect": boolean;
@@ -1658,6 +1662,10 @@ declare namespace LocalJSX {
           * flag to show lookupField for CONVERSATION_PROPERTIES or not
          */
         "showLookupField"?: boolean;
+        /**
+          * flag to show multi select field type or not
+         */
+        "showMultiSelectField"?: boolean;
         /**
           * flag to show relationshipTypeSelect dropdown or not
          */

--- a/packages/crayons-extended/custom-objects/src/components.d.ts
+++ b/packages/crayons-extended/custom-objects/src/components.d.ts
@@ -111,6 +111,10 @@ export namespace Components {
          */
         "showRelationshipTypeSelect": boolean;
         /**
+          * Additional props (e.g. search, debounceTimer) passed through to the target-object fw-select inside fw-fb-field-lookup, for opting in to server-backed/async search on the target picker. Defaults to an empty object, so existing consumers who don't set this see no behavior change.
+         */
+        "targetSelectProps": {};
+        /**
           * Theme configuration for the form builder UI
          */
         "theme": 'default' | 'dew-light-theme' | 'dew-dark-theme';
@@ -299,6 +303,10 @@ export namespace Components {
           * array for target objects
          */
         "targetObjects": any;
+        /**
+          * Additional props (e.g. search, debounceTimer, optionLabelPath) passed through to the target object fw-select, so a consumer can opt in to server-backed/async search for the target picker. Defaults to an empty object, so existing consumers who don't set this see no behavior change.
+         */
+        "targetSelectProps": {};
     }
     interface FwFieldEditor {
         "createDynamicSection": boolean;
@@ -409,6 +417,10 @@ export namespace Components {
          */
         "showRelationshipTypeSelect": boolean;
         "showSections": boolean;
+        /**
+          * Additional props (e.g. search, debounceTimer) passed through to the target-object fw-select inside fw-fb-field-lookup, for opting in to server-backed/async search on the target picker. Defaults to an empty object, so existing consumers who don't set this see no behavior change.
+         */
+        "targetSelectProps": {};
         /**
           * Theme configuration for the form builder UI
          */
@@ -604,6 +616,10 @@ export namespace Components {
     type: string;
     limit?: number;
   }>;
+        /**
+          * Additional props (e.g. search, debounceTimer) passed through to the target-object fw-select inside fw-fb-field-lookup, for opting in to server-backed/async search on the target picker. Defaults to an empty object, so existing consumers who don't set this see no behavior change.
+         */
+        "targetSelectProps": {};
         /**
           * Theme configuration for the form builder UI
          */
@@ -1097,6 +1113,10 @@ declare namespace LocalJSX {
          */
         "showRelationshipTypeSelect"?: boolean;
         /**
+          * Additional props (e.g. search, debounceTimer) passed through to the target-object fw-select inside fw-fb-field-lookup, for opting in to server-backed/async search on the target picker. Defaults to an empty object, so existing consumers who don't set this see no behavior change.
+         */
+        "targetSelectProps"?: {};
+        /**
           * Theme configuration for the form builder UI
          */
         "theme"?: 'default' | 'dew-light-theme' | 'dew-dark-theme';
@@ -1323,6 +1343,10 @@ declare namespace LocalJSX {
           * array for target objects
          */
         "targetObjects"?: any;
+        /**
+          * Additional props (e.g. search, debounceTimer, optionLabelPath) passed through to the target object fw-select, so a consumer can opt in to server-backed/async search for the target picker. Defaults to an empty object, so existing consumers who don't set this see no behavior change.
+         */
+        "targetSelectProps"?: {};
     }
     interface FwFieldEditor {
         "createDynamicSection"?: boolean;
@@ -1449,6 +1473,10 @@ declare namespace LocalJSX {
          */
         "showRelationshipTypeSelect"?: boolean;
         "showSections"?: boolean;
+        /**
+          * Additional props (e.g. search, debounceTimer) passed through to the target-object fw-select inside fw-fb-field-lookup, for opting in to server-backed/async search on the target picker. Defaults to an empty object, so existing consumers who don't set this see no behavior change.
+         */
+        "targetSelectProps"?: {};
         /**
           * Theme configuration for the form builder UI
          */
@@ -1680,6 +1708,10 @@ declare namespace LocalJSX {
     type: string;
     limit?: number;
   }>;
+        /**
+          * Additional props (e.g. search, debounceTimer) passed through to the target-object fw-select inside fw-fb-field-lookup, for opting in to server-backed/async search on the target picker. Defaults to an empty object, so existing consumers who don't set this see no behavior change.
+         */
+        "targetSelectProps"?: {};
         /**
           * Theme configuration for the form builder UI
          */

--- a/packages/crayons-extended/custom-objects/src/components.d.ts
+++ b/packages/crayons-extended/custom-objects/src/components.d.ts
@@ -578,6 +578,10 @@ export namespace Components {
          */
         "role": 'trial' | 'admin';
         /**
+          * flag to show date time field type or not
+         */
+        "showDateTimeField": boolean;
+        /**
           * flag to show dependentField for CONVERSATION_PROPERTIES or not
          */
         "showDependentField": boolean;
@@ -1650,6 +1654,10 @@ declare namespace LocalJSX {
           * Show explore plans button and disable features for free-plan users
          */
         "role"?: 'trial' | 'admin';
+        /**
+          * flag to show date time field type or not
+         */
+        "showDateTimeField"?: boolean;
         /**
           * flag to show dependentField for CONVERSATION_PROPERTIES or not
          */

--- a/packages/crayons-extended/custom-objects/src/components.d.ts
+++ b/packages/crayons-extended/custom-objects/src/components.d.ts
@@ -610,7 +610,7 @@ export namespace Components {
          */
         "supportDependentAndMSDDInSections": boolean;
         /**
-          * Host-driven list of supported field types and optional per-type limits
+          * Host-driven list of supported field types and optional per-type limits. Governs what's visible/creatable in this builder session only: a type left out is hidden from the left-nav, field editor, and customize-widget modal, including any field of that type already present in a loaded schema. Excluded fields' data is left untouched in formValues.fields and will still be included on save - this prop is not a data migration tool, so a host that needs to fully retire a type must filter/migrate the underlying schema itself.
          */
         "supportedFieldTypes": Array<{
     type: string;
@@ -1702,7 +1702,7 @@ declare namespace LocalJSX {
          */
         "supportDependentAndMSDDInSections"?: boolean;
         /**
-          * Host-driven list of supported field types and optional per-type limits
+          * Host-driven list of supported field types and optional per-type limits. Governs what's visible/creatable in this builder session only: a type left out is hidden from the left-nav, field editor, and customize-widget modal, including any field of that type already present in a loaded schema. Excluded fields' data is left untouched in formValues.fields and will still be included on save - this prop is not a data migration tool, so a host that needs to fully retire a type must filter/migrate the underlying schema itself.
          */
         "supportedFieldTypes"?: Array<{
     type: string;

--- a/packages/crayons-extended/custom-objects/src/components.d.ts
+++ b/packages/crayons-extended/custom-objects/src/components.d.ts
@@ -590,6 +590,10 @@ export namespace Components {
          */
         "role": 'trial' | 'admin';
         /**
+          * flag to show/hide the "Customize widget" button, independent of the productName preset's config.customizeWidget value
+         */
+        "showCustomizeWidgetOption": boolean;
+        /**
           * flag to show dependentField for CONVERSATION_PROPERTIES or not
          */
         "showDependentField": boolean;
@@ -1681,6 +1685,10 @@ declare namespace LocalJSX {
           * Show explore plans button and disable features for free-plan users
          */
         "role"?: 'trial' | 'admin';
+        /**
+          * flag to show/hide the "Customize widget" button, independent of the productName preset's config.customizeWidget value
+         */
+        "showCustomizeWidgetOption"?: boolean;
         /**
           * flag to show dependentField for CONVERSATION_PROPERTIES or not
          */

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-drag-drop-item.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-drag-drop-item.tsx
@@ -50,6 +50,12 @@ export class FormBuilderFieldDragDropItem {
    */
   @Prop({ mutable: true }) lookupTargetObjects = false;
   /**
+   * Additional props (e.g. search, debounceTimer) passed through to the target-object fw-select inside
+   * fw-fb-field-lookup, for opting in to server-backed/async search on the target picker. Defaults to an
+   * empty object, so existing consumers who don't set this see no behavior change.
+   */
+  @Prop({ mutable: true }) targetSelectProps = {};
+  /**
    * flag to show dependentField resolve checkbox
    */
   @Prop({ mutable: true }) showDependentFieldResolveProp = false;
@@ -213,6 +219,7 @@ export class FormBuilderFieldDragDropItem {
             enableFilterable={this.enableFilterable}
             defaultFieldTypeSchema={this.defaultFieldTypeSchema}
             lookupTargetObjects={this.lookupTargetObjects}
+            targetSelectProps={this.targetSelectProps}
             formValues={this.formValues}
             isLoading={this.isLoading}
             sectionsExpanded={this.sectionsExpanded}

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-lookup.e2e.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-lookup.e2e.ts
@@ -1,0 +1,67 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('fw-fb-field-lookup', () => {
+  const targetObjects = [
+    { value: 1, text: 'Ticket', isNative: true },
+    { value: 2, text: 'Contact', isNative: true },
+  ];
+
+  it('renders the target select with the static options and no search behavior when targetSelectProps is not set', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<fw-fb-field-lookup></fw-fb-field-lookup>');
+    await page.$eval(
+      'fw-fb-field-lookup',
+      (elm: any, { targetObjects }) => {
+        elm.formValues = { isNew: true };
+        elm.targetObjects = targetObjects;
+      },
+      { targetObjects }
+    );
+    await page.waitForChanges();
+
+    const targetSelect = await page.find('fw-fb-field-lookup >>> .fb-field-lookup-target-select');
+    expect(targetSelect).toBeTruthy();
+
+    const search = await targetSelect.getProperty('search');
+    const debounceTimer = await targetSelect.getProperty('debounceTimer');
+    // unset targetSelectProps (defaults to {}) means neither prop is forwarded - fw-select falls back to its
+    // own default local-filter search and default debounceTimer, i.e. today's behavior, unchanged.
+    expect(search).toBeFalsy();
+    expect(debounceTimer).toBe(300);
+  });
+
+  it('threads a custom search function + debounceTimer from targetSelectProps onto the target select', async () => {
+    await jest.useFakeTimers();
+    const page = await newE2EPage();
+    await page.setContent('<fw-fb-field-lookup></fw-fb-field-lookup>');
+    await page.$eval(
+      'fw-fb-field-lookup',
+      (elm: any, { targetObjects }) => {
+        elm.formValues = { isNew: true };
+        elm.targetObjects = targetObjects;
+        elm.targetSelectProps = {
+          debounceTimer: 0,
+          search: () => Promise.resolve([{ value: 99, text: 'Searched Custom Object' }]),
+        };
+      },
+      { targetObjects }
+    );
+    await page.waitForChanges();
+
+    const input = await page.find('fw-fb-field-lookup >>> .fb-field-lookup-target-select >>> input');
+    await input.click();
+    await page.waitForChanges();
+    await input.press('a');
+    await page.waitForChanges();
+    jest.runAllTimers();
+    await page.waitForChanges();
+    await page.waitForChanges();
+
+    const popover = await page.find('fw-fb-field-lookup >>> .fb-field-lookup-target-select >>> fw-popover');
+    const options = await popover.findAll('fw-list-options >>> fw-select-option');
+    expect(options.length).toBe(1);
+    const selectOption = await options[0].shadowRoot.querySelector('.select-option');
+    expect(selectOption['innerText']).toBe('Searched Custom Object');
+    jest.useRealTimers();
+  });
+});

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-lookup.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-lookup.tsx
@@ -57,6 +57,12 @@ export class FbFieldDropdown {
    */
   @Prop({ mutable: true }) showErrors = false;
   /**
+   * Additional props (e.g. search, debounceTimer, optionLabelPath) passed through to the target object
+   * fw-select, so a consumer can opt in to server-backed/async search for the target picker. Defaults to
+   * an empty object, so existing consumers who don't set this see no behavior change.
+   */
+  @Prop({ mutable: true }) targetSelectProps = {};
+  /**
    * Disables all the options which can't be edited, reordered or deleted if set to true.
    */
   @Prop() disabled = false;
@@ -243,6 +249,7 @@ export class FbFieldDropdown {
             )}
             <div class={`${strBaseClassName}-target-select-container`}>
               <fw-select
+                {...this.targetSelectProps}
                 required={true}
                 state={strTargetState}
                 class={`${strBaseClassName}-target-select`}

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/components/field-editor.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/components/field-editor.tsx
@@ -106,6 +106,12 @@ export class FieldEditor {
    */
   @Prop({ mutable: true }) lookupTargetObjects = false;
   /**
+   * Additional props (e.g. search, debounceTimer) passed through to the target-object fw-select inside
+   * fw-fb-field-lookup, for opting in to server-backed/async search on the target picker. Defaults to an
+   * empty object, so existing consumers who don't set this see no behavior change.
+   */
+  @Prop({ mutable: true }) targetSelectProps = {};
+  /**
    * flag to show dependentField resolve checkbox
    */
   @Prop({ mutable: true }) showDependentFieldResolveProp = false;
@@ -1497,6 +1503,7 @@ export class FieldEditor {
       <fw-fb-field-lookup
         ref={(el) => (this.dictInteractiveElements['relationship'] = el)}
         targetObjects={this.lookupTargetObjects}
+        targetSelectProps={this.targetSelectProps}
         sourceObjectName={this.entityName}
         showErrors={this.showErrors}
         disabled={boolDisableLookup}

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
@@ -2005,6 +2005,55 @@ describe('fw-form-builder', () => {
     );
   });
 
+  it('MULTI_SELECT field should not be shown in left nav when showMultiSelectField is false', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<fw-form-builder show-multi-select-field=false product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+    );
+
+    const leftPanel = await page.find(
+      'fw-form-builder >>> .form-builder-left-panel'
+    );
+    const fieldItems = await leftPanel.findAll(
+      '.form-builder-left-panel-field-types-list > fw-field-type-menu-item'
+    );
+    expect(fieldItems.length).toEqual(
+      formMapper.CUSTOM_OBJECTS.fieldOrder.length - 2
+    );
+
+    for (const fieldItem of fieldItems) {
+      expect(await fieldItem.getProperty('value')).not.toEqual('MULTI_SELECT');
+    }
+  });
+
+  it('MULTI_SELECT field editor should not be shown when showMultiSelectField is false', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<fw-form-builder show-multi-select-field=false product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+    );
+    await page.waitForChanges();
+    await page.$eval(
+      'fw-form-builder',
+      (elm: any, { formValues }: any) => {
+        elm.formValues = formValues;
+      },
+      { formValues: formValues.CUSTOM_OBJECTS }
+    );
+    await page.waitForChanges();
+
+    const rightPanel = await page.find(
+      'fw-form-builder >>> .form-builder-right-panel-field-editor-list'
+    );
+    const fieldDragDropItems = await rightPanel.findAll(
+      'fb-field-drag-drop-item'
+    );
+    expect(fieldDragDropItems.length).toEqual(
+      formValues.CUSTOM_OBJECTS.fields.length - 1
+    );
+  });
+
   it('disables left panel and displays message and button when role is trial, clicking on Explore plan button triggers fwExplorePlan event', async () => {
     const page = await newE2EPage();
 

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
@@ -2054,6 +2054,101 @@ describe('fw-form-builder', () => {
     );
   });
 
+  it('DATE_TIME field should not be shown in left nav when showDateTimeField is false', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<fw-form-builder show-date-time-field=false product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+    );
+
+    const leftPanel = await page.find(
+      'fw-form-builder >>> .form-builder-left-panel'
+    );
+    const fieldItems = await leftPanel.findAll(
+      '.form-builder-left-panel-field-types-list > fw-field-type-menu-item'
+    );
+    expect(fieldItems.length).toEqual(
+      formMapper.CUSTOM_OBJECTS.fieldOrder.length - 1
+    );
+
+    for (const fieldItem of fieldItems) {
+      expect(await fieldItem.getProperty('value')).not.toEqual('DATE_TIME');
+    }
+  });
+
+  it('DATE_TIME field should be shown in left nav after Date when showDateTimeField is true', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<fw-form-builder show-date-time-field=true product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+    );
+
+    const leftPanel = await page.find(
+      'fw-form-builder >>> .form-builder-left-panel'
+    );
+    const fieldItems = await leftPanel.findAll(
+      '.form-builder-left-panel-field-types-list > fw-field-type-menu-item'
+    );
+    expect(fieldItems.length).toEqual(
+      formMapper.CUSTOM_OBJECTS.fieldOrder.length
+    );
+
+    const fieldTypes = await Promise.all(
+      fieldItems.map(async (fieldItem) => fieldItem.getProperty('value'))
+    );
+    const dateIndex = fieldTypes.indexOf('DATE');
+    const dateTimeIndex = fieldTypes.indexOf('DATE_TIME');
+    expect(dateIndex).toBeGreaterThanOrEqual(0);
+    expect(dateTimeIndex).toBe(dateIndex + 1);
+
+    const dateTimeItem = fieldItems[dateTimeIndex];
+    expect(await dateTimeItem.getProperty('iconName')).toEqual('calendar');
+    expect(await dateTimeItem.getProperty('label')).toEqual('fieldTypeDateTime');
+  });
+
+  it('DATE_TIME field editor should not be shown when showDateTimeField is false', async () => {
+    const page = await newE2EPage();
+    const formValuesWithDateTime = {
+      ...formValues.CUSTOM_OBJECTS,
+      fields: [
+        ...formValues.CUSTOM_OBJECTS.fields,
+        {
+          id: 'a87ce74f-07f9-406a-bd18-bef23a5306a1',
+          name: 'datetime',
+          label: 'Date-Time',
+          type: 'DATE_TIME',
+          required: false,
+          field_options: {},
+          filterable: true,
+          searchable: false,
+        },
+      ],
+    };
+
+    await page.setContent(
+      `<fw-form-builder show-date-time-field=false product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+    );
+    await page.waitForChanges();
+    await page.$eval(
+      'fw-form-builder',
+      (elm: any, { formValues }: any) => {
+        elm.formValues = formValues;
+      },
+      { formValues: formValuesWithDateTime }
+    );
+    await page.waitForChanges();
+
+    const rightPanel = await page.find(
+      'fw-form-builder >>> .form-builder-right-panel-field-editor-list'
+    );
+    const fieldDragDropItems = await rightPanel.findAll(
+      'fb-field-drag-drop-item'
+    );
+    expect(fieldDragDropItems.length).toEqual(
+      formValuesWithDateTime.fields.length - 1
+    );
+  });
+
   it('disables left panel and displays message and button when role is trial, clicking on Explore plan button triggers fwExplorePlan event', async () => {
     const page = await newE2EPage();
 

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
@@ -2036,8 +2036,11 @@ describe('fw-form-builder', () => {
     const fieldItems = await leftPanel.findAll(
       '.form-builder-left-panel-field-types-list > fw-field-type-menu-item'
     );
+    // -2, not -1: renderFieldTypeElement always hides PRIMARY from this
+    // "add field" palette (it's implicit, non-addable) on top of the
+    // MULTI_SELECT exclusion from supportedFieldTypes.
     expect(fieldItems.length).toEqual(
-      formMapper.CUSTOM_OBJECTS.fieldOrder.length - 1
+      formMapper.CUSTOM_OBJECTS.fieldOrder.length - 2
     );
 
     for (const fieldItem of fieldItems) {
@@ -2097,8 +2100,10 @@ describe('fw-form-builder', () => {
     const fieldItems = await leftPanel.findAll(
       '.form-builder-left-panel-field-types-list > fw-field-type-menu-item'
     );
+    // -2, not -1: same PRIMARY carve-out as the MULTI_SELECT exclusion test
+    // above, on top of the DATE_TIME exclusion from supportedFieldTypes.
     expect(fieldItems.length).toEqual(
-      formMapper.CUSTOM_OBJECTS.fieldOrder.length - 1
+      formMapper.CUSTOM_OBJECTS.fieldOrder.length - 2
     );
 
     for (const fieldItem of fieldItems) {
@@ -2119,8 +2124,11 @@ describe('fw-form-builder', () => {
     const fieldItems = await leftPanel.findAll(
       '.form-builder-left-panel-field-types-list > fw-field-type-menu-item'
     );
+    // -1: renderFieldTypeElement always hides PRIMARY from this "add
+    // field" palette (it's implicit, non-addable), independent of
+    // supportedFieldTypes - nothing is excluded here otherwise.
     expect(fieldItems.length).toEqual(
-      formMapper.CUSTOM_OBJECTS.fieldOrder.length
+      formMapper.CUSTOM_OBJECTS.fieldOrder.length - 1
     );
 
     const fieldTypes = await Promise.all(
@@ -2180,6 +2188,52 @@ describe('fw-form-builder', () => {
     );
     expect(fieldDragDropItems.length).toEqual(
       formValuesWithDateTime.fields.length - 1
+    );
+  });
+
+  it('disables the left-nav item once a host-provided per-type limit is reached', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<fw-form-builder product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+    );
+    await page.waitForChanges();
+    await page.$eval(
+      'fw-form-builder',
+      (elm: any, { formValues, supportedFieldTypes }: any) => {
+        elm.formValues = formValues;
+        elm.supportedFieldTypes = supportedFieldTypes;
+      },
+      {
+        // formValues.CUSTOM_OBJECTS already has 2 fields counted as TEXT
+        // (1 PRIMARY, which the component parses as TEXT for count
+        // purposes, + 1 TEXT) - a host-provided limit of 1 should disable
+        // TEXT. DATE_TIME is absent from the fixture and left at its
+        // default (no override), so it acts as a control and must stay
+        // enabled.
+        formValues: formValues.CUSTOM_OBJECTS,
+        supportedFieldTypes: [{ type: 'TEXT', limit: 1 }, { type: 'DATE_TIME' }],
+      }
+    );
+    await page.waitForChanges();
+
+    const leftPanel = await page.find(
+      'fw-form-builder >>> .form-builder-left-panel'
+    );
+    const fieldItems = await leftPanel.findAll(
+      '.form-builder-left-panel-field-types-list > fw-field-type-menu-item'
+    );
+    const fieldTypeValues = await Promise.all(
+      fieldItems.map((item) => item.getProperty('value'))
+    );
+    const textIndex = fieldTypeValues.indexOf('TEXT');
+    const dateTimeIndex = fieldTypeValues.indexOf('DATE_TIME');
+    expect(textIndex).toBeGreaterThanOrEqual(0);
+    expect(dateTimeIndex).toBeGreaterThanOrEqual(0);
+
+    expect(await fieldItems[textIndex].getProperty('disabled')).toBe(true);
+    expect(await fieldItems[dateTimeIndex].getProperty('disabled')).toBe(
+      false
     );
   });
 

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
@@ -2005,12 +2005,30 @@ describe('fw-form-builder', () => {
     );
   });
 
-  it('MULTI_SELECT field should not be shown in left nav when showMultiSelectField is false', async () => {
+  const customObjectsFieldTypesWithoutMultiSelect =
+    formMapper.CUSTOM_OBJECTS.fieldOrder
+      .filter((type) => type !== 'MULTI_SELECT')
+      .map((type) => ({ type }));
+
+  const customObjectsFieldTypesWithoutDateTime =
+    formMapper.CUSTOM_OBJECTS.fieldOrder
+      .filter((type) => type !== 'DATE_TIME')
+      .map((type) => ({ type }));
+
+  it('MULTI_SELECT field should not be shown in left nav when supportedFieldTypes excludes it', async () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      `<fw-form-builder show-multi-select-field=false product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+      `<fw-form-builder product-name="CUSTOM_OBJECTS"></fw-form-builder>`
     );
+    await page.$eval(
+      'fw-form-builder',
+      (elm: any, { supportedFieldTypes }: any) => {
+        elm.supportedFieldTypes = supportedFieldTypes;
+      },
+      { supportedFieldTypes: customObjectsFieldTypesWithoutMultiSelect }
+    );
+    await page.waitForChanges();
 
     const leftPanel = await page.find(
       'fw-form-builder >>> .form-builder-left-panel'
@@ -2019,7 +2037,7 @@ describe('fw-form-builder', () => {
       '.form-builder-left-panel-field-types-list > fw-field-type-menu-item'
     );
     expect(fieldItems.length).toEqual(
-      formMapper.CUSTOM_OBJECTS.fieldOrder.length - 2
+      formMapper.CUSTOM_OBJECTS.fieldOrder.length - 1
     );
 
     for (const fieldItem of fieldItems) {
@@ -2027,19 +2045,23 @@ describe('fw-form-builder', () => {
     }
   });
 
-  it('MULTI_SELECT field editor should not be shown when showMultiSelectField is false', async () => {
+  it('MULTI_SELECT field editor should not be shown when supportedFieldTypes excludes it', async () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      `<fw-form-builder show-multi-select-field=false product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+      `<fw-form-builder product-name="CUSTOM_OBJECTS"></fw-form-builder>`
     );
     await page.waitForChanges();
     await page.$eval(
       'fw-form-builder',
-      (elm: any, { formValues }: any) => {
+      (elm: any, { formValues, supportedFieldTypes }: any) => {
+        elm.supportedFieldTypes = supportedFieldTypes;
         elm.formValues = formValues;
       },
-      { formValues: formValues.CUSTOM_OBJECTS }
+      {
+        supportedFieldTypes: customObjectsFieldTypesWithoutMultiSelect,
+        formValues: formValues.CUSTOM_OBJECTS,
+      }
     );
     await page.waitForChanges();
 
@@ -2054,12 +2076,20 @@ describe('fw-form-builder', () => {
     );
   });
 
-  it('DATE_TIME field should not be shown in left nav when showDateTimeField is false', async () => {
+  it('DATE_TIME field should not be shown in left nav when supportedFieldTypes excludes it', async () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      `<fw-form-builder show-date-time-field=false product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+      `<fw-form-builder product-name="CUSTOM_OBJECTS"></fw-form-builder>`
     );
+    await page.$eval(
+      'fw-form-builder',
+      (elm: any, { supportedFieldTypes }: any) => {
+        elm.supportedFieldTypes = supportedFieldTypes;
+      },
+      { supportedFieldTypes: customObjectsFieldTypesWithoutDateTime }
+    );
+    await page.waitForChanges();
 
     const leftPanel = await page.find(
       'fw-form-builder >>> .form-builder-left-panel'
@@ -2076,11 +2106,11 @@ describe('fw-form-builder', () => {
     }
   });
 
-  it('DATE_TIME field should be shown in left nav after Date when showDateTimeField is true', async () => {
+  it('DATE_TIME field should be shown in left nav after Date when supportedFieldTypes includes it', async () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      `<fw-form-builder show-date-time-field=true product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+      `<fw-form-builder product-name="CUSTOM_OBJECTS"></fw-form-builder>`
     );
 
     const leftPanel = await page.find(
@@ -2106,7 +2136,7 @@ describe('fw-form-builder', () => {
     expect(await dateTimeItem.getProperty('label')).toEqual('fieldTypeDateTime');
   });
 
-  it('DATE_TIME field editor should not be shown when showDateTimeField is false', async () => {
+  it('DATE_TIME field editor should not be shown when supportedFieldTypes excludes it', async () => {
     const page = await newE2EPage();
     const formValuesWithDateTime = {
       ...formValues.CUSTOM_OBJECTS,
@@ -2126,15 +2156,19 @@ describe('fw-form-builder', () => {
     };
 
     await page.setContent(
-      `<fw-form-builder show-date-time-field=false product-name="CUSTOM_OBJECTS"></fw-form-builder>`
+      `<fw-form-builder product-name="CUSTOM_OBJECTS"></fw-form-builder>`
     );
     await page.waitForChanges();
     await page.$eval(
       'fw-form-builder',
-      (elm: any, { formValues }: any) => {
+      (elm: any, { formValues, supportedFieldTypes }: any) => {
+        elm.supportedFieldTypes = supportedFieldTypes;
         elm.formValues = formValues;
       },
-      { formValues: formValuesWithDateTime }
+      {
+        supportedFieldTypes: customObjectsFieldTypesWithoutDateTime,
+        formValues: formValuesWithDateTime,
+      }
     );
     await page.waitForChanges();
 

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.e2e.ts
@@ -1987,6 +1987,30 @@ describe('fw-form-builder', () => {
     expect(element).toBeFalsy();
   });
 
+  it('does not render customize widget button when showCustomizeWidgetOption is false', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-form-builder show-customize-widget-option="false"></fw-form-builder>'
+    );
+    const element = await page.find(
+      'fw-form-builder >>> #customizeWidgetFieldsBtn'
+    );
+    expect(element).toBeFalsy();
+  });
+
+  it('renders customize widget button when showCustomizeWidgetOption is true', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-form-builder show-customize-widget-option="true"></fw-form-builder>'
+    );
+    const element = await page.find(
+      'fw-form-builder >>> #customizeWidgetFieldsBtn'
+    );
+    expect(element).toBeTruthy();
+  });
+
   it('RELATIONSHIP field should not be shown when showLookupField is false', async () => {
     const page = await newE2EPage();
 

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -16,7 +16,9 @@ import {
   deepCloneObject,
   getFieldTypeCheckboxes,
   getMappedCustomFieldType,
+  buildAllowedFieldTypesConfig,
   getMaximumLimitsConfig,
+  mergeHostFieldLimits,
   hasCustomProperty,
   hasPermission,
   i18nText,
@@ -45,7 +47,9 @@ export class FormBuilder {
   private modalCustomizeWidget!: any;
   private isWidgetValuesChanged = false;
   private filterByFieldTypeOptions = null;
-  private supportedFieldTypes;
+  private allowedFieldTypes: string[] = [];
+  private hostFieldLimits: Record<string, number> = {};
+  private effectiveMaximumLimits = null;
   private resizeObserver;
   private FILTER_ALL_FIELDS = 'ALL_FIELDS';
 
@@ -99,13 +103,12 @@ export class FormBuilder {
    */
   @Prop({ mutable: true }) showDependentField = true;
   /**
-   * flag to show multi select field type or not
+   * Host-driven list of supported field types and optional per-type limits
    */
-  @Prop({ mutable: true }) showMultiSelectField = true;
-  /**
-   * flag to show date time field type or not
-   */
-  @Prop({ mutable: true }) showDateTimeField = false;
+  @Prop({ mutable: true }) supportedFieldTypes: Array<{
+    type: string;
+    limit?: number;
+  }> = null;
   /**
    * flag to show dependentField resolve checkbox
    */
@@ -261,21 +264,37 @@ export class FormBuilder {
 
   componentWillLoad(): void {
     this.initializeSearchDebounce();
+    this.initializeAllowedFieldTypes();
     this.validateFormValues();
-    this.supportedFieldTypes = [
-      'TEXT',
-      'EMAIL',
-      'CHECKBOX',
-      'PARAGRAPH',
-      'NUMBER',
-      'DECIMAL',
-      'DATE',
-      ...(this.showDateTimeField ? ['DATE_TIME'] : []),
-      'DROPDOWN',
-      'DEPENDENT_FIELD',
-      'RELATIONSHIP',
-      ...(this.showMultiSelectField ? ['MULTI_SELECT'] : []),
-    ];
+  }
+
+  @Watch('supportedFieldTypes')
+  onSupportedFieldTypesChange(): void {
+    this.initializeAllowedFieldTypes();
+  }
+
+  private initializeAllowedFieldTypes(): void {
+    const { allowedFieldTypes, hostFieldLimits } = buildAllowedFieldTypesConfig(
+      this.productName,
+      this.supportedFieldTypes
+    );
+    this.allowedFieldTypes = allowedFieldTypes;
+    this.hostFieldLimits = hostFieldLimits;
+    this.effectiveMaximumLimits = mergeHostFieldLimits(
+      getMaximumLimitsConfig(this.productName),
+      this.hostFieldLimits
+    );
+  }
+
+  private isFieldTypeAllowed(strFieldType: string): boolean {
+    return this.allowedFieldTypes.includes(strFieldType);
+  }
+
+  private getEffectiveMaximumLimits() {
+    return (
+      this.effectiveMaximumLimits ??
+      getMaximumLimitsConfig(this.productName)
+    );
   }
 
   disconnectedCallback(): void {
@@ -414,7 +433,7 @@ export class FormBuilder {
           }
         }
 
-        const objMaxLimits = getMaximumLimitsConfig(this.productName);
+        const objMaxLimits = this.getEffectiveMaximumLimits();
         this.enableFieldType =
           intValidActiveFieldCount < objMaxLimits.fields.count;
         this.enableFilterable =
@@ -432,7 +451,7 @@ export class FormBuilder {
   private getInterpolatedMaxLimitLabel = (strProperty) => {
     if (strProperty && strProperty !== '') {
       try {
-        const objMaxLimit = getMaximumLimitsConfig(this.productName)?.[
+        const objMaxLimit = this.getEffectiveMaximumLimits()?.[
           strProperty
         ];
         if (objMaxLimit) {
@@ -520,15 +539,12 @@ export class FormBuilder {
     intIndex = -1,
     sectionData?
   ) => {
-    if (strNewFieldType === 'MULTI_SELECT' && !this.showMultiSelectField) {
-      return;
-    }
-    if (strNewFieldType === 'DATE_TIME' && !this.showDateTimeField) {
+    if (!this.isFieldTypeAllowed(strNewFieldType)) {
       return;
     }
     const fieldType = strNewFieldType;
     const objNewField = deepCloneObject(presetSchema.fieldTypes[fieldType]);
-    const objMaxLimits = getMaximumLimitsConfig(this.productName);
+    const objMaxLimits = this.getEffectiveMaximumLimits();
 
     try {
       const arrFields = this.localFormValues?.fields;
@@ -568,7 +584,7 @@ export class FormBuilder {
       objNewField.type
     );
     this.fwComposeNewField.emit({
-      maximumLimits: getMaximumLimitsConfig(this.productName),
+      maximumLimits: this.getEffectiveMaximumLimits(),
       fieldSchema: objNewField,
       value: { ...objFieldData },
       index: intIndex,
@@ -868,7 +884,7 @@ export class FormBuilder {
         arrWidgetIds = [...arrWidgetIds, arrPrecedenceObjects[0]];
       }
 
-      const objMaxLimits = getMaximumLimitsConfig(this.productName);
+      const objMaxLimits = this.getEffectiveMaximumLimits();
       const intMaxWidgetFields = objMaxLimits?.widgets?.count || 0;
       const intFieldsLength = arrFields.length;
       for (let f1 = 0; f1 < intFieldsLength; f1++) {
@@ -916,7 +932,7 @@ export class FormBuilder {
     if (this.arrWidgetFields) {
       // const strFieldName = event.detail.data.name;
       const strFieldID = event.detail.data.id;
-      const objMaxLimits = getMaximumLimitsConfig(this.productName);
+      const objMaxLimits = this.getEffectiveMaximumLimits();
       const intMaxWidgetsCount = objMaxLimits?.widgets?.count || 0;
 
       if (boolChecked && this.arrWidgetFields.length < intMaxWidgetsCount) {
@@ -1087,7 +1103,7 @@ export class FormBuilder {
     const dataItem = presetFieldTypes[key];
     const strFieldType = dataItem.type;
 
-    if (!this.supportedFieldTypes.includes(strFieldType)) {
+    if (!this.isFieldTypeAllowed(strFieldType)) {
       return null;
     }
 
@@ -1096,7 +1112,7 @@ export class FormBuilder {
       ? this.getInterpolatedMaxLimitLabel('fields')
       : '';
 
-    const objMaxLimits = getMaximumLimitsConfig(this.productName);
+    const objMaxLimits = this.getEffectiveMaximumLimits();
     if (
       !boolDisableFieldType &&
       hasCustomProperty(this.fieldTypesCount, strFieldType) &&
@@ -1443,10 +1459,7 @@ export class FormBuilder {
       return null;
     }
     const strFieldType = dataItem.type;
-    if (strFieldType === 'MULTI_SELECT' && !this.showMultiSelectField) {
-      return null;
-    }
-    if (strFieldType === 'DATE_TIME' && !this.showDateTimeField) {
+    if (!this.isFieldTypeAllowed(strFieldType)) {
       return null;
     }
     const objDefaultFieldTypeSchema =
@@ -1512,7 +1525,7 @@ export class FormBuilder {
   }
 
   private renderWidgetElement(dataItem, intIndex) {
-    const objMaxLimits = getMaximumLimitsConfig(this.productName);
+    const objMaxLimits = this.getEffectiveMaximumLimits();
     const intMaxWidgetsCount = objMaxLimits?.widgets?.count || 0;
 
     const isPrimaryField = isPrimaryFieldType(
@@ -1553,31 +1566,20 @@ export class FormBuilder {
     const objProductPreset = formMapper[this.productName];
     const objProductPresetConfig = objProductPreset?.config;
     const objLabelsDb = objProductPreset?.labels;
-    const arrFieldOrder = objProductPreset?.fieldOrder;
-    if (!this.showLookupField) {
-      const relationshipIndex = arrFieldOrder.indexOf('RELATIONSHIP');
-      if (relationshipIndex > -1) {
-        arrFieldOrder.splice(relationshipIndex, 1);
+    const arrFieldOrder = [...(objProductPreset?.fieldOrder ?? [])].filter(
+      (fieldType) => {
+        if (!this.isFieldTypeAllowed(fieldType)) {
+          return false;
+        }
+        if (fieldType === 'RELATIONSHIP' && !this.showLookupField) {
+          return false;
+        }
+        if (fieldType === 'DEPENDENT_FIELD' && !this.showDependentField) {
+          return false;
+        }
+        return true;
       }
-    }
-    if (!this.showDependentField) {
-      const dependentIndex = arrFieldOrder.indexOf('DEPENDENT_FIELD');
-      if (dependentIndex > -1) {
-        arrFieldOrder.splice(dependentIndex, 1);
-      }
-    }
-    if (!this.showMultiSelectField) {
-      const multiSelectIndex = arrFieldOrder.indexOf('MULTI_SELECT');
-      if (multiSelectIndex > -1) {
-        arrFieldOrder.splice(multiSelectIndex, 1);
-      }
-    }
-    if (!this.showDateTimeField) {
-      const dateTimeIndex = arrFieldOrder.indexOf('DATE_TIME');
-      if (dateTimeIndex > -1) {
-        arrFieldOrder.splice(dateTimeIndex, 1);
-      }
-    }
+    );
     const boolFieldEditingState = !!Object.keys(this.currentFieldIndex).length;
     const strEntityName = objFormValuesSchema ? objFormValuesSchema.name : '';
     const strFieldEditHeader = hasCustomProperty(objLabelsDb, 'fieldsHeader')

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -17,8 +17,10 @@ import {
   getFieldTypeCheckboxes,
   getMappedCustomFieldType,
   buildAllowedFieldTypesConfig,
+  buildVisibleFieldIndexMap,
   getMaximumLimitsConfig,
   mergeHostFieldLimits,
+  resolveDroppedIndex,
   hasCustomProperty,
   hasPermission,
   i18nText,
@@ -50,6 +52,12 @@ export class FormBuilder {
   private allowedFieldTypes: string[] = [];
   private hostFieldLimits: Record<string, number> = {};
   private effectiveMaximumLimits = null;
+  // Maps a rendered (DOM) child ordinal in the main fields drag container to
+  // its real index inside arrFieldElements, since fields whose type is
+  // excluded via isFieldTypeAllowed render as null and contribute no DOM
+  // node. Rebuilt every render() alongside fieldElements; see
+  // resolveDroppedIndex().
+  private visibleFieldIndexMap: number[] = [];
   private resizeObserver;
   private FILTER_ALL_FIELDS = 'ALL_FIELDS';
 
@@ -109,7 +117,14 @@ export class FormBuilder {
    */
   @Prop({ mutable: true }) showDependentField = true;
   /**
-   * Host-driven list of supported field types and optional per-type limits
+   * Host-driven list of supported field types and optional per-type limits.
+   * Governs what's visible/creatable in this builder session only: a type
+   * left out is hidden from the left-nav, field editor, and
+   * customize-widget modal, including any field of that type already
+   * present in a loaded schema. Excluded fields' data is left untouched in
+   * formValues.fields and will still be included on save - this prop is
+   * not a data migration tool, so a host that needs to fully retire a type
+   * must filter/migrate the underlying schema itself.
    */
   @Prop({ mutable: true }) supportedFieldTypes: Array<{
     type: string;
@@ -665,7 +680,16 @@ export class FormBuilder {
     this.removeFieldReorderClass();
     const objDetail = event.detail;
     const elFieldType = objDetail.droppedElement;
-    const intDroppedIndex = objDetail.droppedIndex;
+    let intDroppedIndex = objDetail.droppedIndex;
+    // Only the main fields list can have hidden (isFieldTypeAllowed-excluded)
+    // entries interspersed, so only remap drops landing there - a section's
+    // own drag container never renders excluded top-level field types.
+    if (objDetail.dropToId?.includes('fieldsContainer')) {
+      intDroppedIndex = resolveDroppedIndex(
+        intDroppedIndex,
+        this.visibleFieldIndexMap
+      );
+    }
     let sectionData = {
       data: dataItem,
       name: sectionName,
@@ -894,6 +918,18 @@ export class FormBuilder {
       const intMaxWidgetFields = objMaxLimits?.widgets?.count || 0;
       const intFieldsLength = arrFields.length;
       for (let f1 = 0; f1 < intFieldsLength; f1++) {
+        // Don't newly offer a type the host has excluded via
+        // supportedFieldTypes as a widget candidate (mirrors the
+        // field-editor/left-nav allowlist). Fields already saved as widget
+        // fields via customizeWidgetFields (arrPrecedenceObjects, above)
+        // are untouched - we only gate what gets freshly added here.
+        const strWidgetFieldType = arrFields[f1]?.type;
+        if (
+          strWidgetFieldType !== 'PRIMARY' &&
+          !this.isFieldTypeAllowed(strWidgetFieldType)
+        ) {
+          continue;
+        }
         if (!arrWidgetIds.includes(arrFields[f1].id)) {
           arrWidgetIds = [...arrWidgetIds, arrFields[f1].id];
         }
@@ -1536,6 +1572,13 @@ export class FormBuilder {
   }
 
   private renderWidgetElement(dataItem, intIndex) {
+    const strFieldType = dataItem?.type;
+    // Same allowlist carve-out as renderFieldEditorElement: hide a field
+    // whose type the host has excluded via supportedFieldTypes from the
+    // customize-widget modal too, PRIMARY excepted since it's implicit.
+    if (strFieldType !== 'PRIMARY' && !this.isFieldTypeAllowed(strFieldType)) {
+      return null;
+    }
     const objMaxLimits = this.getEffectiveMaximumLimits();
     const intMaxWidgetsCount = objMaxLimits?.widgets?.count || 0;
 
@@ -1636,9 +1679,23 @@ export class FormBuilder {
           )
         : null;
 
+    // fieldElements entries are null wherever isFieldTypeAllowed() excluded
+    // the field (see renderFieldEditorElement), so they contribute no DOM
+    // node under fw-drag-container. Use the actually-rendered count (not
+    // the raw array length) to decide whether to show the "no results"
+    // empty state, and rebuild the visible-ordinal -> real index map
+    // consumed by resolveDroppedIndex() in fieldTypeDropHandler.
+    const arrRenderedFieldElements = fieldElements
+      ? fieldElements.filter((element) => element != null)
+      : [];
+    this.visibleFieldIndexMap = buildVisibleFieldIndexMap(
+      arrFieldElements,
+      (fieldType) => this.isFieldTypeAllowed(fieldType)
+    );
+
     const boolShowEmptySearchResults =
-      (this.searching && (!fieldElements || fieldElements.length === 0)) ||
-      (boolFilterApplied && (!fieldElements || fieldElements.length === 0));
+      (this.searching && arrRenderedFieldElements.length === 0) ||
+      (boolFilterApplied && arrRenderedFieldElements.length === 0);
     const boolHasCustomizeWidgetOption =
       objProductPresetConfig?.customizeWidget || false;
     const fieldWidgetElements =

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -91,6 +91,12 @@ export class FormBuilder {
    */
   @Prop({ mutable: true }) lookupTargetObjects = null;
   /**
+   * Additional props (e.g. search, debounceTimer) passed through to the target-object fw-select inside
+   * fw-fb-field-lookup, for opting in to server-backed/async search on the target picker. Defaults to an
+   * empty object, so existing consumers who don't set this see no behavior change.
+   */
+  @Prop({ mutable: true }) targetSelectProps = {};
+  /**
    * flag to show lookupField for CONVERSATION_PROPERTIES or not
    */
   @Prop({ mutable: true }) showLookupField = true;
@@ -1498,6 +1504,7 @@ export class FormBuilder {
         enableFilterable={this.enableFilterable}
         defaultFieldTypeSchema={objDefaultFieldTypeSchema}
         lookupTargetObjects={this.lookupTargetObjects}
+        targetSelectProps={this.targetSelectProps}
         formValues={this.localFormValues}
         isLoading={this.isLoading}
         showDependentFieldResolveProp={this.showDependentFieldResolveProp}

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -99,6 +99,10 @@ export class FormBuilder {
    */
   @Prop({ mutable: true }) showDependentField = true;
   /**
+   * flag to show multi select field type or not
+   */
+  @Prop({ mutable: true }) showMultiSelectField = true;
+  /**
    * flag to show dependentField resolve checkbox
    */
   @Prop({ mutable: true }) showDependentFieldResolveProp = true;
@@ -266,7 +270,7 @@ export class FormBuilder {
       'DROPDOWN',
       'DEPENDENT_FIELD',
       'RELATIONSHIP',
-      'MULTI_SELECT',
+      ...(this.showMultiSelectField ? ['MULTI_SELECT'] : []),
     ];
   }
 
@@ -512,6 +516,9 @@ export class FormBuilder {
     intIndex = -1,
     sectionData?
   ) => {
+    if (strNewFieldType === 'MULTI_SELECT' && !this.showMultiSelectField) {
+      return;
+    }
     const fieldType = strNewFieldType;
     const objNewField = deepCloneObject(presetSchema.fieldTypes[fieldType]);
     const objMaxLimits = getMaximumLimitsConfig(this.productName);
@@ -1429,6 +1436,9 @@ export class FormBuilder {
       return null;
     }
     const strFieldType = dataItem.type;
+    if (strFieldType === 'MULTI_SELECT' && !this.showMultiSelectField) {
+      return null;
+    }
     const objDefaultFieldTypeSchema =
       this.getDefaultFieldTypeSchema(strFieldType);
     if (!objDefaultFieldTypeSchema) {
@@ -1544,6 +1554,12 @@ export class FormBuilder {
       const dependentIndex = arrFieldOrder.indexOf('DEPENDENT_FIELD');
       if (dependentIndex > -1) {
         arrFieldOrder.splice(dependentIndex, 1);
+      }
+    }
+    if (!this.showMultiSelectField) {
+      const multiSelectIndex = arrFieldOrder.indexOf('MULTI_SELECT');
+      if (multiSelectIndex > -1) {
+        arrFieldOrder.splice(multiSelectIndex, 1);
       }
     }
     const boolFieldEditingState = !!Object.keys(this.currentFieldIndex).length;

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -103,6 +103,10 @@ export class FormBuilder {
    */
   @Prop({ mutable: true }) showMultiSelectField = true;
   /**
+   * flag to show date time field type or not
+   */
+  @Prop({ mutable: true }) showDateTimeField = false;
+  /**
    * flag to show dependentField resolve checkbox
    */
   @Prop({ mutable: true }) showDependentFieldResolveProp = true;
@@ -266,7 +270,7 @@ export class FormBuilder {
       'NUMBER',
       'DECIMAL',
       'DATE',
-      'DATE_TIME',
+      ...(this.showDateTimeField ? ['DATE_TIME'] : []),
       'DROPDOWN',
       'DEPENDENT_FIELD',
       'RELATIONSHIP',
@@ -517,6 +521,9 @@ export class FormBuilder {
     sectionData?
   ) => {
     if (strNewFieldType === 'MULTI_SELECT' && !this.showMultiSelectField) {
+      return;
+    }
+    if (strNewFieldType === 'DATE_TIME' && !this.showDateTimeField) {
       return;
     }
     const fieldType = strNewFieldType;
@@ -1439,6 +1446,9 @@ export class FormBuilder {
     if (strFieldType === 'MULTI_SELECT' && !this.showMultiSelectField) {
       return null;
     }
+    if (strFieldType === 'DATE_TIME' && !this.showDateTimeField) {
+      return null;
+    }
     const objDefaultFieldTypeSchema =
       this.getDefaultFieldTypeSchema(strFieldType);
     if (!objDefaultFieldTypeSchema) {
@@ -1560,6 +1570,12 @@ export class FormBuilder {
       const multiSelectIndex = arrFieldOrder.indexOf('MULTI_SELECT');
       if (multiSelectIndex > -1) {
         arrFieldOrder.splice(multiSelectIndex, 1);
+      }
+    }
+    if (!this.showDateTimeField) {
+      const dateTimeIndex = arrFieldOrder.indexOf('DATE_TIME');
+      if (dateTimeIndex > -1) {
+        arrFieldOrder.splice(dateTimeIndex, 1);
       }
     }
     const boolFieldEditingState = !!Object.keys(this.currentFieldIndex).length;

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -1465,7 +1465,11 @@ export class FormBuilder {
       return null;
     }
     const strFieldType = dataItem.type;
-    if (!this.isFieldTypeAllowed(strFieldType)) {
+    // PRIMARY is an implicit, non-addable field that every entity already
+    // has - it should never be hidden by the addable-types allowlist, which
+    // only governs what can be newly composed (mirrors the same carve-out
+    // in renderFieldTypeElement's palette rendering).
+    if (strFieldType !== 'PRIMARY' && !this.isFieldTypeAllowed(strFieldType)) {
       return null;
     }
     const objDefaultFieldTypeSchema =

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -147,6 +147,11 @@ export class FormBuilder {
    */
   @Prop({ mutable: true }) customizeWidgetFields = null;
   /**
+   * flag to show/hide the "Customize widget" button, independent of the
+   * productName preset's config.customizeWidget value
+   */
+  @Prop({ mutable: true }) showCustomizeWidgetOption = true;
+  /**
    * flag to notify if an api call is in progress
    */
   @Prop({ mutable: true }) isLoading = false;
@@ -1697,7 +1702,8 @@ export class FormBuilder {
       (this.searching && arrRenderedFieldElements.length === 0) ||
       (boolFilterApplied && arrRenderedFieldElements.length === 0);
     const boolHasCustomizeWidgetOption =
-      objProductPresetConfig?.customizeWidget || false;
+      (objProductPresetConfig?.customizeWidget || false) &&
+      this.showCustomizeWidgetOption;
     const fieldWidgetElements =
       this.showCustomizeWidget &&
       arrFieldElements &&

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.spec.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.spec.ts
@@ -18,6 +18,8 @@ import {
   getParentId,
   getChildChoices,
   getMaximumLimitsConfig,
+  mergeHostFieldLimits,
+  buildAllowedFieldTypesConfig,
 } from './form-builder-utils';
 
 describe('getFieldBasedOnLevel', () => {
@@ -622,5 +624,40 @@ describe('getMaximumLimitsConfig', () => {
   it('returns null when productName is not found in formMapper', () => {
     const result = getMaximumLimitsConfig('OTHER_PRODUCT');
     expect(result).toBeNull();
+  });
+});
+
+describe('mergeHostFieldLimits', () => {
+  it('overrides existing field type limit counts', () => {
+    const baseLimits = {
+      TEXT: { count: 80, message: 'maximumLimits.fields' },
+    };
+    const result = mergeHostFieldLimits(baseLimits, { TEXT: 5 });
+    expect(result.TEXT.count).toBe(5);
+    expect(result.TEXT.message).toBe('maximumLimits.fields');
+  });
+
+  it('adds limit entry for unknown field types', () => {
+    const result = mergeHostFieldLimits({}, { DATE_TIME: 10 });
+    expect(result.DATE_TIME.count).toBe(10);
+  });
+});
+
+describe('buildAllowedFieldTypesConfig', () => {
+  it('returns allowed types and host limits from supportedFieldTypes prop', () => {
+    const result = buildAllowedFieldTypesConfig('CUSTOM_OBJECTS', [
+      { type: 'TEXT', limit: 5 },
+      { type: 'DATE' },
+    ]);
+    expect(result.allowedFieldTypes).toEqual(['TEXT', 'DATE']);
+    expect(result.hostFieldLimits).toEqual({ TEXT: 5 });
+  });
+
+  it('falls back to product fieldOrder when supportedFieldTypes prop is empty', () => {
+    const result = buildAllowedFieldTypesConfig('CUSTOM_OBJECTS', null);
+    expect(result.allowedFieldTypes).toEqual(
+      expect.arrayContaining(['TEXT', 'DATE', 'MULTI_SELECT', 'DATE_TIME'])
+    );
+    expect(result.hostFieldLimits).toEqual({});
   });
 });

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.spec.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.spec.ts
@@ -20,6 +20,8 @@ import {
   getMaximumLimitsConfig,
   mergeHostFieldLimits,
   buildAllowedFieldTypesConfig,
+  buildVisibleFieldIndexMap,
+  resolveDroppedIndex,
 } from './form-builder-utils';
 
 describe('getFieldBasedOnLevel', () => {
@@ -659,5 +661,75 @@ describe('buildAllowedFieldTypesConfig', () => {
       expect.arrayContaining(['TEXT', 'DATE', 'MULTI_SELECT', 'DATE_TIME'])
     );
     expect(result.hostFieldLimits).toEqual({});
+  });
+});
+
+describe('buildVisibleFieldIndexMap', () => {
+  const isFieldTypeAllowed = (allowed: string[]) => (type: string) =>
+    allowed.includes(type);
+
+  it('maps every field 1:1 when nothing is excluded', () => {
+    const fields = [
+      { type: 'PRIMARY' },
+      { type: 'TEXT' },
+      { type: 'MULTI_SELECT' },
+    ];
+    const result = buildVisibleFieldIndexMap(
+      fields,
+      isFieldTypeAllowed(['TEXT', 'MULTI_SELECT'])
+    );
+    expect(result).toEqual([0, 1, 2]);
+  });
+
+  it('skips the real index of any excluded, non-PRIMARY field type', () => {
+    // Mirrors a legacy schema with MULTI_SELECT sitting mid-list, which is
+    // what P0-1 flagged: index 2 (MULTI_SELECT) must be absent from the
+    // map, not just trimmed off the end.
+    const fields = [
+      { type: 'PRIMARY' },
+      { type: 'TEXT' },
+      { type: 'MULTI_SELECT' },
+      { type: 'DATE' },
+    ];
+    const result = buildVisibleFieldIndexMap(
+      fields,
+      isFieldTypeAllowed(['TEXT', 'DATE'])
+    );
+    expect(result).toEqual([0, 1, 3]);
+  });
+
+  it('always keeps PRIMARY visible even if it is not in the allowlist', () => {
+    const fields = [{ type: 'PRIMARY' }, { type: 'TEXT' }];
+    const result = buildVisibleFieldIndexMap(fields, isFieldTypeAllowed([]));
+    expect(result).toEqual([0]);
+  });
+});
+
+describe('resolveDroppedIndex', () => {
+  it('returns the DOM ordinal unchanged when there is no visible-index map', () => {
+    expect(resolveDroppedIndex(2, [])).toBe(2);
+    expect(resolveDroppedIndex(2, null)).toBe(2);
+  });
+
+  it('remaps an in-range DOM ordinal to the real array index, skipping a hidden mid-list field', () => {
+    // arrFieldElements = [PRIMARY(0), TEXT(1), MULTI_SELECT(2, hidden), DATE(3)]
+    // Rendered DOM children, in order, are indices [0, 1, 3].
+    const arrVisibleFieldIndexMap = [0, 1, 3];
+
+    // Dropping on the 3rd rendered child (DOM ordinal 2) must resolve to
+    // the real array index 3 (DATE), not 2 (the hidden MULTI_SELECT).
+    expect(resolveDroppedIndex(2, arrVisibleFieldIndexMap)).toBe(3);
+    // Dropping on the 1st/2nd rendered child is unaffected, since no
+    // hidden field precedes them.
+    expect(resolveDroppedIndex(0, arrVisibleFieldIndexMap)).toBe(0);
+    expect(resolveDroppedIndex(1, arrVisibleFieldIndexMap)).toBe(1);
+  });
+
+  it('places a drop after the last visible field right after its real index, not at the absolute array end', () => {
+    // arrFieldElements = [TEXT(0), MULTI_SELECT(1, hidden)]; only TEXT
+    // renders, so the only valid DOM ordinal is 0 (before TEXT) or 1
+    // (after TEXT, i.e. past the last visible child).
+    const arrVisibleFieldIndexMap = [0];
+    expect(resolveDroppedIndex(1, arrVisibleFieldIndexMap)).toBe(1);
   });
 });

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.ts
@@ -182,6 +182,46 @@ export function buildAllowedFieldTypesConfig(
   }
 }
 
+// Builds a map from "nth field actually rendered in the main fields drag
+// container" -> "real index of that field in arrFieldElements". Needed
+// because a field whose type isFieldTypeAllowed excludes renders as null
+// (see renderFieldEditorElement) and contributes no DOM node, so a raw
+// DOM-child-position count (draggable.ts's droppedIndex) undercounts the
+// true array index by the number of hidden fields preceding it.
+export function buildVisibleFieldIndexMap(
+  arrFieldElements: any[],
+  isFieldTypeAllowed: (fieldType: string) => boolean
+): number[] {
+  const arrMap: number[] = [];
+  (arrFieldElements || []).forEach((dataItem, idx) => {
+    const strFieldType = dataItem?.type;
+    const boolVisible =
+      strFieldType === 'PRIMARY' || isFieldTypeAllowed(strFieldType);
+    if (boolVisible) {
+      arrMap.push(idx);
+    }
+  });
+  return arrMap;
+}
+
+// Converts a drop position reported as a DOM child ordinal back into the
+// real index within arrFieldElements, using the map built above.
+export function resolveDroppedIndex(
+  intDroppedIndex: number,
+  arrVisibleFieldIndexMap: number[]
+): number {
+  if (!arrVisibleFieldIndexMap || arrVisibleFieldIndexMap.length === 0) {
+    return intDroppedIndex;
+  }
+  if (intDroppedIndex < arrVisibleFieldIndexMap.length) {
+    return arrVisibleFieldIndexMap[intDroppedIndex];
+  }
+  // Dropped after the last visible field - place it right after that
+  // field's real index rather than at the absolute end of the array, so
+  // it doesn't jump past any hidden fields trailing the visible list.
+  return arrVisibleFieldIndexMap[arrVisibleFieldIndexMap.length - 1] + 1;
+}
+
 // function to get the max limit config from mapper
 export function getMaxLimitProperty(
   productName = 'CUSTOM_OBJECTS',

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.ts
@@ -119,6 +119,11 @@ export function isUniqueField(objField) {
   return false;
 }
 
+export type SupportedFieldTypeConfig = {
+  type: string;
+  limit?: number;
+};
+
 // function to retreive maximum Limits object based on the db type
 export function getMaximumLimitsConfig(productName = 'CUSTOM_OBJECTS') {
   try {
@@ -127,6 +132,54 @@ export function getMaximumLimitsConfig(productName = 'CUSTOM_OBJECTS') {
     // eslint-disable-next-line no-empty
   } catch (error) {}
   return null;
+}
+
+export function mergeHostFieldLimits(
+  baseLimits: Record<string, any> | null,
+  hostFieldLimits: Record<string, number>
+) {
+  if (!baseLimits) {
+    return null;
+  }
+  const mergedLimits = deepCloneObject(baseLimits);
+  Object.entries(hostFieldLimits).forEach(([fieldType, limit]) => {
+    if (mergedLimits[fieldType]) {
+      mergedLimits[fieldType] = { ...mergedLimits[fieldType], count: limit };
+    } else {
+      mergedLimits[fieldType] = {
+        count: limit,
+        message: 'maximumLimits.fields',
+      };
+    }
+  });
+  return mergedLimits;
+}
+
+export function buildAllowedFieldTypesConfig(
+  productName = 'CUSTOM_OBJECTS',
+  supportedFieldTypesProp: SupportedFieldTypeConfig[] | null = null
+): {
+  allowedFieldTypes: string[];
+  hostFieldLimits: Record<string, number>;
+} {
+  const hostFieldLimits: Record<string, number> = {};
+
+  if (Array.isArray(supportedFieldTypesProp) && supportedFieldTypesProp.length) {
+    const allowedFieldTypes = supportedFieldTypesProp.map(({ type, limit }) => {
+      if (typeof limit === 'number') {
+        hostFieldLimits[type] = limit;
+      }
+      return type;
+    });
+    return { allowedFieldTypes, hostFieldLimits };
+  }
+
+  try {
+    const fieldOrder = formMapper[productName]?.fieldOrder ?? [];
+    return { allowedFieldTypes: [...fieldOrder], hostFieldLimits };
+  } catch (error) {
+    return { allowedFieldTypes: [], hostFieldLimits };
+  }
 }
 
 // function to get the max limit config from mapper

--- a/packages/crayons-i18n/i18n/en-US.json
+++ b/packages/crayons-i18n/i18n/en-US.json
@@ -93,7 +93,7 @@
     "fieldTypeNumber": "Number",
     "fieldTypeDecimal": "Decimal",
     "fieldTypeDate": "Date",
-    "fieldTypeDateTime": "Date Time",
+    "fieldTypeDateTime": "Date-Time",
     "fieldTypeDropdown": "Dropdown",
     "fieldTypeCheckbox": "Checkbox",
     "fieldTypeMultiselect": "Multi select",


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


**Summary**
fw-form-builder can now be told which field types a host application supports, and optionally cap how many of each type can be added, entirely via props - no code change needed on the crayons side to roll a new field type out gradually.

supportedFieldTypes prop (replaces the earlier, never-merged show-multi-select-field interim prop): Array<{ type: string; limit?: number }>. Controls both which field types appear in the "add field" palette / can be composed, and (via the optional limit) overrides the built-in per-type maximum for that type.

// Before (interim, never merged)
show-multi-select-field="false"

// After
supportedFieldTypes={fieldOrder.filter(t => t !== 'MULTI_SELECT').map(type => ({ type }))}
DATE_TIME field type added to CUSTOM_OBJECTS (preset, mapper, limits).

targetSelectProps prop (separate concern, added in a follow-up commit): threads through additional props (e.g. search, debounceTimer) to the target-object fw-select inside fw-fb-field-lookup, so a host can opt a lookup field into server-backed/async search instead of the static option list. Defaults to {}, so existing consumers are unaffected.

**Behavior notes / known limitation**
When a host excludes a type via supportedFieldTypes, any existing field of that type already present in a loaded schema is hidden from the left-nav, field editor, and customize-widget modal - but its data is left untouched in formValues.fields and will still be included on save. This is intentional: the prop controls what's visible/creatable in the builder UI, not a data migration tool. Hosts that need to fully retire a type from a schema should filter/migrate the underlying data themselves.

