### PR TITLE
fix: datepicker is unable to format sweden dates when dd mmm yyyy display format is used

### DIFF
--- a/packages/crayons-core/src/components/datepicker/datepicker-utils.spec.ts
+++ b/packages/crayons-core/src/components/datepicker/datepicker-utils.spec.ts
@@ -1,0 +1,109 @@
+import { isValid, format } from 'date-fns';
+import sv from 'date-fns/locale/sv';
+import enUS from 'date-fns/locale/en-US';
+import {
+  toWideMonthFormat,
+  parseSwedishDate,
+  parseDatepickerValue,
+  matchDatepickerValue,
+} from './datepicker-utils';
+
+const displayFormat = 'dd MMM yyyy';
+const referenceDate = new Date(2026, 0, 1);
+const svLocale = { locale: sv };
+
+describe('datepicker-utils', () => {
+  describe('toWideMonthFormat', () => {
+    it('replaces MMM with MMMM in abbreviated month formats', () => {
+      expect(toWideMonthFormat('dd MMM yyyy')).toBe('dd MMMM yyyy');
+      expect(toWideMonthFormat('MMM dd, yyyy')).toBe('MMMM dd, yyyy');
+    });
+  });
+
+  describe('parseSwedishDate', () => {
+    it.each([
+      '28 juli 2026',
+      '28 mars 2026',
+      '15 juni 2026',
+      '15 jan. 2026',
+      '10 sep. 2026',
+    ])('parses Swedish date "%s" with dd MMM yyyy format', (value) => {
+      const parsed = parseSwedishDate(
+        value,
+        displayFormat,
+        referenceDate,
+        svLocale
+      );
+      expect(isValid(parsed)).toBe(true);
+    });
+
+    it('returns the value when value is empty', () => {
+      expect(parseSwedishDate('', displayFormat, referenceDate, svLocale)).toBe(
+        ''
+      );
+    });
+  });
+
+  describe('parseDatepickerValue', () => {
+    it('parses Swedish display format using wide month names', () => {
+      const parsed = parseDatepickerValue(
+        '28 juli 2026',
+        displayFormat,
+        referenceDate,
+        svLocale
+      );
+      expect(format(parsed, displayFormat, { locale: sv })).toBe(
+        '28 juli 2026'
+      );
+    });
+
+    it('parses default locale display format', () => {
+      const parsed = parseDatepickerValue(
+        '07/28/2026',
+        'MM/dd/yyyy',
+        referenceDate,
+        { locale: enUS }
+      );
+      expect(isValid(parsed)).toBe(true);
+      expect(format(parsed, 'MM/dd/yyyy')).toBe('07/28/2026');
+    });
+
+    it('returns the value when value is empty', () => {
+      expect(
+        parseDatepickerValue('', displayFormat, referenceDate, svLocale)
+      ).toBe('');
+    });
+  });
+
+  describe('matchDatepickerValue', () => {
+    it.each(['28 juli 2026', '28 mars 2026', '15 juni 2026', '15 jan. 2026'])(
+      'matches valid Swedish date "%s"',
+      (value) => {
+        expect(matchDatepickerValue(value, displayFormat, svLocale)).toBe(true);
+      }
+    );
+
+    it('rejects invalid Swedish date strings', () => {
+      expect(matchDatepickerValue('28 foo 2026', displayFormat, svLocale)).toBe(
+        false
+      );
+    });
+
+    it('validates non-Swedish locales using display format', () => {
+      expect(
+        matchDatepickerValue('07/28/2026', 'MM/dd/yyyy', { locale: enUS })
+      ).toBe(true);
+      expect(
+        matchDatepickerValue('not-a-date', 'MM/dd/yyyy', { locale: enUS })
+      ).toBe(false);
+    });
+
+    it('returns true for Icelandic locale', () => {
+      expect(
+        matchDatepickerValue('20.04.2022', displayFormat, {
+          locale: { code: 'is' },
+        })
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/crayons-core/src/components/datepicker/datepicker-utils.ts
+++ b/packages/crayons-core/src/components/datepicker/datepicker-utils.ts
@@ -1,0 +1,76 @@
+import { parse as parseDate, isMatch as parseIsMatch } from 'date-fns';
+
+export const toWideMonthFormat = (displayFormat: string): string =>
+  displayFormat.replace(/MMM(?!M)/g, 'MMMM');
+
+export const parseSwedishDate = (
+  value: string,
+  displayFormat: string,
+  date: Date,
+  langModule: any
+): any => {
+  // date-fns parse with MMM fails for Swedish months whose abbreviated name
+  // matches the wide name (e.g. mars, juni, juli). Parse with MMMM instead.
+  if (!value) return value;
+  return parseDate(value, toWideMonthFormat(displayFormat), date, langModule);
+};
+
+export const parseIcelandicDate = (value: string, langModule: any): any => {
+  // For Icelandic language, the date format is different. There is a discrepency which is handled in this PR https://github.com/date-fns/date-fns/pull/3934
+  if (!value) return value;
+  const icelandicLanguageDisplayFormat = 'dd MMMM yyyy';
+  const icelandicMonthMapper = {
+    'jan.': 'jan.',
+    'feb.': 'feb.',
+    'mars': 'm',
+    'apríl': 'apríl',
+    'maí': 'maí',
+    'júní': 'júní',
+    'júlí': 'júlí',
+    'ágúst': 'á',
+    'sept.': 's',
+    'okt.': 'ó',
+    'nóv.': 'n',
+    'des.': 'd',
+  };
+  const correctedDate = value?.replace(
+    /jan\.|feb\.|mars|apríl|maí|júní|júlí|ágúst|sept\.|okt\.|nóv\.|des\./g,
+    (match) => icelandicMonthMapper[match]
+  );
+  return parseDate(
+    correctedDate,
+    icelandicLanguageDisplayFormat,
+    new Date(),
+    langModule
+  );
+};
+
+export const parseDatepickerValue = (
+  value: string,
+  displayFormat: string,
+  date: Date,
+  langModule: any
+): any => {
+  if (!value) return value;
+  if (langModule?.locale?.code === 'is' && displayFormat === 'dd MMM yyyy') {
+    return parseIcelandicDate(value, langModule);
+  }
+  if (langModule?.locale?.code === 'sv' && /MMM(?!M)/.test(displayFormat)) {
+    return parseSwedishDate(value, displayFormat, date, langModule);
+  }
+  return parseDate(value, displayFormat, date, langModule);
+};
+
+export const matchDatepickerValue = (
+  value: string,
+  displayFormat: string,
+  langModule: any
+): boolean => {
+  if (langModule?.locale?.code === 'is') {
+    return true;
+  }
+  if (langModule?.locale?.code === 'sv' && /MMM(?!M)/.test(displayFormat)) {
+    return parseIsMatch(value, toWideMonthFormat(displayFormat), langModule);
+  }
+  return parseIsMatch(value, displayFormat, langModule);
+};

--- a/packages/crayons-core/src/components/datepicker/datepicker.e2e.ts
+++ b/packages/crayons-core/src/components/datepicker/datepicker.e2e.ts
@@ -850,4 +850,75 @@ describe('fw-datepicker', () => {
     const alertElement = await shadow.find('.invalid-alert');
     expect(alertElement).toBeFalsy();
   });
+
+  describe('Swedish locale with dd MMM yyyy display format', () => {
+    const swedishDatepicker = (
+      attrs = 'locale="sv" display-format="dd MMM yyyy"'
+    ) => `<fw-datepicker ${attrs}></fw-datepicker>`;
+
+    const getInvalidAlert = async (page) => {
+      const shadow = await page.find(
+        'fw-datepicker >>> fw-input >>> :first-child'
+      );
+      return shadow.find('.invalid-alert');
+    };
+
+    it('should format ISO value as Swedish display format on load', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        swedishDatepicker('locale="sv" display-format="dd MMM yyyy" value="2026-07-28"')
+      );
+      await page.waitForChanges();
+      const dp = await page.find('fw-datepicker');
+      const val = await dp.getProperty('value');
+      expect(val).toBe('28 juli 2026');
+      const alertElement = await getInvalidAlert(page);
+      expect(alertElement).toBeFalsy();
+    });
+
+    it.each([
+      ['28 juli 2026', '2026-07-28'],
+      ['28 mars 2026', '2026-03-28'],
+      ['15 juni 2026', '2026-06-15'],
+      ['15 jan. 2026', '2026-01-15'],
+    ])(
+      'should accept Swedish display format "%s" when value is set programmatically',
+      async (displayValue, isoValue) => {
+        const page = await newE2EPage();
+        await page.setContent(swedishDatepicker());
+        await page.waitForChanges();
+        const dp = await page.find('fw-datepicker');
+        await dp.setProperty('value', displayValue);
+        await page.waitForChanges();
+        const val = await dp.getProperty('value');
+        expect(val).toBe(displayValue);
+        const alertElement = await getInvalidAlert(page);
+        expect(alertElement).toBeFalsy();
+        const isoVal = await dp.callMethod('getValue');
+        expect(isoVal).toContain(isoValue);
+      }
+    );
+
+    it('should show error for invalid Swedish display format', async () => {
+      const page = await newE2EPage();
+      await page.setContent(swedishDatepicker());
+      await page.waitForChanges();
+      const dp = await page.find('fw-datepicker');
+      await dp.setProperty('value', '28 foo 2026');
+      await page.waitForChanges();
+      const alertElement = await getInvalidAlert(page);
+      expect(alertElement).toBeTruthy();
+    });
+
+    it('should validate non-Swedish display format for default locale', async () => {
+      const page = await newE2EPage();
+      await page.setContent('<fw-datepicker value="2022-07-31"></fw-datepicker>');
+      await page.waitForChanges();
+      const dp = await page.find('fw-datepicker');
+      await dp.setProperty('value', 'not-a-date');
+      await page.waitForChanges();
+      const alertElement = await getInvalidAlert(page);
+      expect(alertElement).toBeTruthy();
+    });
+  });
 });

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -82,6 +82,16 @@ const getWeekDays = (lang): any => {
   );
 };
 
+const toWideMonthFormat = (displayFormat) =>
+  displayFormat.replace(/MMM(?!M)/g, 'MMMM');
+
+const parseSwedishDate = (value, displayFormat, date, langModule) => {
+  // date-fns parse with MMM fails for Swedish months whose abbreviated name
+  // matches the wide name (e.g. mars, juni, juli). Parse with MMMM instead.
+  if (!value) return value;
+  return parseDate(value, toWideMonthFormat(displayFormat), date, langModule);
+};
+
 const parseIcelandicDate = (value, langModule) => {
   // For Icelandic language, the date format is different. There is a discrepency which is handled in this PR https://github.com/date-fns/date-fns/pull/3934
   if (!value) return value;
@@ -117,14 +127,20 @@ const parse = (value, displayFormat, date, langModule) => {
   if (langModule?.locale?.code === 'is' && displayFormat === 'dd MMM yyyy') {
     return parseIcelandicDate(value, langModule);
   }
+  if (langModule?.locale?.code === 'sv' && /MMM(?!M)/.test(displayFormat)) {
+    return parseSwedishDate(value, displayFormat, date, langModule);
+  }
   return parseDate(value, displayFormat, date, langModule);
 };
 
 const isMatch = (value, displayFormat, langModule) => {
-  if (langModule?.locale?.code !== 'is') {
-    return parseIsMatch(value, displayFormat, langModule);
+  if (langModule?.locale?.code === 'is') {
+    return true;
   }
-  return true;
+  if (langModule?.locale?.code === 'sv' && /MMM(?!M)/.test(displayFormat)) {
+    return parseIsMatch(value, toWideMonthFormat(displayFormat), langModule);
+  }
+  return parseIsMatch(value, displayFormat, langModule);
 };
 
 @Component({ tag: 'fw-datepicker', styleUrl: 'datepicker.scss', shadow: true })

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -12,7 +12,6 @@ import {
 } from '@stencil/core';
 import {
   isValid,
-  parse as parseDate,
   parseISO,
   getYear,
   getMonth,
@@ -21,7 +20,6 @@ import {
   startOfDay,
   getDaysInMonth,
   format,
-  isMatch as parseIsMatch,
   formatISO,
   addDays,
   startOfWeek,
@@ -37,6 +35,10 @@ import FieldControl from '../../function-components/field-control';
 
 import { TranslationController } from '../../global/Translation';
 import { addRTL } from '../../utils';
+import {
+  parseDatepickerValue as parse,
+  matchDatepickerValue as isMatch,
+} from './datepicker-utils';
 
 const defaultweekDays = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
@@ -80,67 +82,6 @@ const getWeekDays = (lang): any => {
   return Array.from(Array(7)).map((_e, i) =>
     format(addDays(startOfWeek(new Date()), i), 'EEEEE', { locale: lang })
   );
-};
-
-const toWideMonthFormat = (displayFormat) =>
-  displayFormat.replace(/MMM(?!M)/g, 'MMMM');
-
-const parseSwedishDate = (value, displayFormat, date, langModule) => {
-  // date-fns parse with MMM fails for Swedish months whose abbreviated name
-  // matches the wide name (e.g. mars, juni, juli). Parse with MMMM instead.
-  if (!value) return value;
-  return parseDate(value, toWideMonthFormat(displayFormat), date, langModule);
-};
-
-const parseIcelandicDate = (value, langModule) => {
-  // For Icelandic language, the date format is different. There is a discrepency which is handled in this PR https://github.com/date-fns/date-fns/pull/3934
-  if (!value) return value;
-  const icelandicLanguageDisplayFormat = 'dd MMMM yyyy';
-  const icelandicMonthMapper = {
-    'jan.': 'jan.',
-    'feb.': 'feb.',
-    'mars': 'm',
-    'apríl': 'apríl',
-    'maí': 'maí',
-    'júní': 'júní',
-    'júlí': 'júlí',
-    'ágúst': 'á',
-    'sept.': 's',
-    'okt.': 'ó',
-    'nóv.': 'n',
-    'des.': 'd',
-  };
-  const correctedDate = value?.replace(
-    /jan\.|feb\.|mars|apríl|maí|júní|júlí|ágúst|sept\.|okt\.|nóv\.|des\./g,
-    (match) => icelandicMonthMapper[match]
-  );
-  return parseDate(
-    correctedDate,
-    icelandicLanguageDisplayFormat,
-    new Date(),
-    langModule
-  );
-};
-
-const parse = (value, displayFormat, date, langModule) => {
-  if (!value) return value;
-  if (langModule?.locale?.code === 'is' && displayFormat === 'dd MMM yyyy') {
-    return parseIcelandicDate(value, langModule);
-  }
-  if (langModule?.locale?.code === 'sv' && /MMM(?!M)/.test(displayFormat)) {
-    return parseSwedishDate(value, displayFormat, date, langModule);
-  }
-  return parseDate(value, displayFormat, date, langModule);
-};
-
-const isMatch = (value, displayFormat, langModule) => {
-  if (langModule?.locale?.code === 'is') {
-    return true;
-  }
-  if (langModule?.locale?.code === 'sv' && /MMM(?!M)/.test(displayFormat)) {
-    return parseIsMatch(value, toWideMonthFormat(displayFormat), langModule);
-  }
-  return parseIsMatch(value, displayFormat, langModule);
 };
 
 @Component({ tag: 'fw-datepicker', styleUrl: 'datepicker.scss', shadow: true })


### PR DESCRIPTION
**Summary:**
Fixes Swedish (locale="sv") date parsing in fw-datepicker when using abbreviated month display formats like dd MMM yyyy.

For several Swedish months — including mars, juni, and juli — the abbreviated (MMM) and wide (MMMM) month names are identical. date-fns parse() with MMM fails on these values, so dates such as 28 juli 2026 were treated as invalid: the input showed an error state, calendar selection did not sync, and validation failed.

The fix adds a Swedish-specific parsing path (similar to the existing Icelandic workaround) that converts MMM → MMMM in the format string before parsing, and applies the same logic in isMatch() for validation.

Also fixes a bug in isMatch() where non-Icelandic locales always returned true, skipping format validation. Non-Swedish locales now use parseIsMatch() correctly.




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
